### PR TITLE
Fix wrong holding graphics

### DIFF
--- a/avatar - four nations restored/interface/province.gfx
+++ b/avatar - four nations restored/interface/province.gfx
@@ -3250,6 +3250,12 @@ spriteTypes = {
 		norefcount = yes
 	}
 	spriteType = {
+		name = "GFX_settlement_castle_earthgfx"
+		texturefile = "gfx\\interface\\placeholder_castle_mongol.tga"
+		noOfFrames = 1
+		norefcount = yes
+	}
+	spriteType = {
 		name = "GFX_settlement_castle_sunwarriorgfx"
 		texturefile = "gfx\\interface\\placeholder_castle_sunwarriorgfx.tga"
 		noOfFrames = 1
@@ -3361,6 +3367,12 @@ spriteTypes = {
 	}
 	spriteType = {
 		name = "GFX_settlement_temple_fireislandergfx_mesoamericangfx"
+		texturefile = "gfx\\interface\\placeholder_temple_fireislandergfx.tga"
+		noOfFrames = 1
+		norefcount = yes
+	}
+	spriteType = {
+		name = "GFX_settlement_temple_fireislandergfx_chinesegfx"
 		texturefile = "gfx\\interface\\placeholder_temple_fireislandergfx.tga"
 		noOfFrames = 1
 		norefcount = yes


### PR DESCRIPTION
Fixed wrong image for earth feudal's castle and fire islander's temple.
The earth feudal culture graphics somehow doesn't fallback to mongolgfx, so it was using the default one (which is the fire feudal castle one).