### PR TITLE
Old Zuko trait change

### DIFF
--- a/avatar - four nations restored/history/characters/firelord_characters.txt
+++ b/avatar - four nations restored/history/characters/firelord_characters.txt
@@ -518,7 +518,6 @@
 	  mother = 53023
 	  disallow_random_traits = yes
 	  trait = firebender
-	  trait = firelord
 	  trait = legendary_bender
 	  trait = innerflame
 	  trait = lightningbender
@@ -527,6 +526,9 @@
       539.1.5 = {
       	birth = yes
       }
+	742.8.13 = {
+		add_trait = firelord
+	}
 	772.3.30 = {
       	death = yes
       }


### PR DESCRIPTION
Old Zuko (Father of Sozin) no longer starts with the firelord trait in the fall of chin scenario.