### PR TITLE
Chaejin vs Zoryu tweaks

### DIFF
--- a/avatar - four nations restored/common/bookmarks/00_bookmarks.txt
+++ b/avatar - four nations restored/common/bookmarks/00_bookmarks.txt
@@ -64,12 +64,28 @@ bm_fall_of_chin = {
 		title_name = k_fire_nation
 		
 		character = {
-			dna = 000000d0000
-			properties = ei0ace00000000
+			dna = rnbpmaoyxep
+			properties = si00jb00000000
 			religion = "fire_spirituality"
 			culture = "fire_islander"
-			government = feudal_government
+			government = fire_feudal_government
 			dynasty = 7
+		}
+	}
+	selectable_character = { # Chaejin Saowon
+		id = 54003 # Chaejin
+		age = 47
+		name = ERA_CHAR_NAME_54003
+		title = k_western_fire_nation
+		title_name = k_western_fire_nation
+		
+		character = {
+			dna = vdubhyomxea
+			properties = rkubec00000000
+			religion = "fire_spirituality"
+			culture = "fire_islander"
+			government = fire_feudal_government
+			dynasty = 3995
 		}
 	}
 }
@@ -81,7 +97,7 @@ bm_peasent_rebellion = {
 	
 	era = no
 
-	# Important Characters: Kyoshi, Earth King, Lord Hong
+	# Important Characters: Kyoshi, Earth King, Firelord Zoryu
 	selectable_character = {
 		id = 34 # Kyoshi
 	}
@@ -89,7 +105,10 @@ bm_peasent_rebellion = {
 		id = 35 # King Jian
 	}
 	selectable_character = {
-		id = 45 # Lord Hong
+		id = 52018 # Firelord Zoryu
+	}
+	selectable_character = {
+		id = 54005 # Shinda Soawon
 	}
 	selectable_character = {
 		id = 9673 # Lord Atonal

--- a/avatar - four nations restored/history/characters/atla_characters.txt
+++ b/avatar - four nations restored/history/characters/atla_characters.txt
@@ -2090,7 +2090,6 @@
 		add_trait = deceitful
 	}
 	931.1.24 = {
-		religion = bhanti_spirituality
 		remove_trait = cruel
 	}
 	933.1.24 = {

--- a/avatar - four nations restored/history/characters/firelord_characters.txt
+++ b/avatar - four nations restored/history/characters/firelord_characters.txt
@@ -448,6 +448,7 @@
 	  trait = humble
 	  trait = wroth
 	  trait = bad_king_fire
+	  trait = canon_character
       521.11.6 = {
       	birth = yes
       }
@@ -539,11 +540,20 @@
 	  trait = innerflame
 	  trait = lightningbender
 	  trait = mastermind_theologian
-	  trait = folk_legend
+	  trait = fire_sage
 	  trait = canon_character
+	  trait = content
+	  trait = chaste
+	  trait = trusting
+	  trait = patient
+	  trait = gregarious
+	  trait = slothful
       539.1.5 = {
       	birth = yes
       }
+	  639.1.15 = {
+		add_trait = folk_legend
+	}
 	742.8.13 = {
 		add_trait = firelord
 	}

--- a/avatar - four nations restored/history/titles/c_ryutozan.txt
+++ b/avatar - four nations restored/history/titles/c_ryutozan.txt
@@ -5,13 +5,13 @@
 	law = revoke_title_voting_power_1
 	law = execution_voting_power_1
 }
-542.1.13 = {
+542.1.13 = { #chaejin
     holder = 54003
 }
-#573.7.24 = {
-#	holder = 8577
-#}
-615.2.13 = {
+588.8.24 = { #Shinda
+	holder = 54005
+}
+623.8.15 = {
 	holder = 8583
 }
 643.10.14 = {

--- a/avatar - four nations restored/history/titles/k_fire_nation.txt
+++ b/avatar - four nations restored/history/titles/k_fire_nation.txt
@@ -1,6 +1,9 @@
 539.1.18 = { #Zoryu
 	holder = 52018
 }
+580.1.11 = {
+	law = succ_gavelkind
+}
 638.9.21 = { #Kazuhiro
 	holder = 43
 }

--- a/avatar - four nations restored/localisation/000_atla_custom_titles.csv
+++ b/avatar - four nations restored/localisation/000_atla_custom_titles.csv
@@ -755,6 +755,7 @@ ERA_CHAR_NAME_8;Firelord Sozin;A;A;;A;;;;;;;;;x
 ERA_CHAR_NAME_6;Earth Queen Ji Houa;A;A;;A;;;;;;;;;x
 ERA_CHAR_NAME_1;Avatar Kyoshi;A;A;;A;;;;;;;;;x
 ERA_CHAR_NAME_52018;Zoryu Rakurai;A;A;;A;;;;;;;;;x
+ERA_CHAR_NAME_54003;Chaejin Saowon;A;A;;A;;;;;;;;;x
 ERA_CHAR_NAME_29966;Prince Jin;A;A;;A;;;;;;;;;x
 ERA_CHAR_NAME_38990;Prince Shige;A;A;;A;;;;;;;;;x
 ERA_CHAR_INFO_29966;The Warlord of the North, the eldest surviving son of Chin the Great, and rightful heir to his empire.;A;A;;A;;;;;;;;;x
@@ -764,6 +765,7 @@ ERA_CHAR_INFO_2;Firstborn of his father, inheritor of the great Fire Nation, Fir
 ERA_CHAR_INFO_31;The 50th Earth Queen Ji Houa, Monarch of Ba Sing Se, Queen of the Earth Kingdom and rightful ruler of it's territories. Under her father's reign, generations of stagnant peace was shattered by the Fire Nation's ruthless incursion into Earth Kingdom territory. After so many years of the Royal Court ignoring the crisis, war has finally arrived and foreign invaders sweep across the lands. A strong monarch must take control once again to steer the Earth Kingdom to survival.;A;A;;A;;;;;;;;;x
 ERA_CHAR_INFO_34;The great and renown Avatar Kyoshi, born a peasant on the most distant shores of the Earth Kingdom, Kyoshi lived for over centuries, seeing many world shaping events pass. Perhaps one of the most lawful of Avatars, Kyoshi restored the order which her predecessor, Avatar Kurak, neglected. The Avatar's power was so great, it was said she split what is now known as Kyoshi Island from the mainland when she defeated Chin the Conqueror.;A;A;;A;;;;;;;;;x
 ERA_CHAR_INFO_52018;Firelord Zoryu has become the new Firelord after his father, Chaeryu's death. However tensions are high, as his illegitimate half-brother, Chaejin, claims the throne. Will you decide who comes out ontop?.;A;A;;A;;;;;;;;;x
+ERA_CHAR_INFO_54003;After an unsuccesful bid for the throne, Chaejin was imprisoned during the Camellia-Peony War. However, Chaejin has yet to give up his claim, and has escaped imprisonment with the help of his followers.Fire nobles around the island have chosen there sides, will you win this second Camellia-Peony War?;A;A;;A;;;;;;;;;x
 BM_SOZIN;Sozin's Coronation;A;A;;A;;;;;;;;;x
 BM_SOZIN_ERA;Sozin's Coronation;A;A;;A;;;;;;;;;x
 BM_SOZIN_ERA_INFO;With the passing of his father, Sozin was crowned as Fire Lord, leader of the advanced and prosperous Fire Nation. Meanwhile, the Earth Kingdom continues to fracture under the watch of yet another Earth King who is a mere puppet of Ba Sing Se's treacherous royal court. As Sozin's friend, Avatar Roku, travels the world to learn the four elements, a celestial body once again hurtles towards the world, a comet said to pass through the skies once a century, always bringing the greatest of change as it burns through the skies...;A;A;;A;;;;;;;;;x


### PR DESCRIPTION
-Added additional bookmark details in Fall of Chin
-Made certain characters live longer.
-Fixed Firelord Zuko (Sozin's father) having "Folk Legend" at the Fall of Chin scenario.
-removed Azula having bhanti spirituality in later start dates, now she is Fire Imperialist until further changes.
-Added new interesting character in Ba Sing Se rebellions start date, Shinda Saowon, son of Chaejin.
-Shinda Soawon is probably one of the hardest starting scenarios in the mod, can you fulfill your father's legacy and become Firelord?
-Updated the Localisation Files.