### PR TITLE
EK trait fix

### DIFF
--- a/avatar - four nations restored/events/ATLA_earthking.txt
+++ b/avatar - four nations restored/events/ATLA_earthking.txt
@@ -7,12 +7,11 @@ character_event = {
 	only_rulers = yes
 	
 	trigger = {
-		primary_title = {
-			OR = {
-				title = e_earth_kingdom
-				title = k_earth_kingdom
-			}
+		OR = {
+			has_landed_title = e_earth_kingdom
+			has_landed_title = k_earth_kingdom
 		}
+		independent = yes
 		NOR = {
 			trait = earthkingpuppet
 			trait = earthking
@@ -108,14 +107,20 @@ character_event = {
 			trait = earthkingpuppet
 			trait = earthking
 		}
-		AND = {
-			primary_title = {
-				OR = {
-					title = e_earth_kingdom
-					title = k_earth_kingdom
+		OR = {
+			AND = {
+				primary_title = {
+					OR = {
+						title = e_earth_kingdom
+						title = k_earth_kingdom
+					}
 				}
+				independent = no
 			}
-			independent = no
+			NOR = {
+				has_landed_title = e_earth_kingdom
+				has_landed_title = k_earth_kingdom
+			}
 		}
 	}
 	option = {


### PR DESCRIPTION
EK traits should now be assigned properly and remain as long as a character holds the required titles and is independent, without having to set them to primary titles. They will remove themselves if the respective titles are lost or the character is no longer independent