### PR TITLE
fix ek mandate.1 "add_character_modifier" bug

### DIFF
--- a/avatar - four nations restored/events/ATLA_mandate.txt
+++ b/avatar - four nations restored/events/ATLA_mandate.txt
@@ -76,8 +76,8 @@ character_event = {
 				}
 				revoke_law = ze_admin_territories
 				add_law = ze_admin_anarchy
+				set_variable = { which = global_royalAuthority value = -10 }
 				PREV = {
-					set_variable = { which = global_royalAuthority value = -10 }
 					add_character_modifier = {
 						name = ek_law_low_mandate_change 
 						years = 10
@@ -90,8 +90,8 @@ character_event = {
 				}
 				revoke_law = ze_admin_province
 				add_law = ze_admin_territories
+				set_variable = { which = global_royalAuthority value = -10 }	
 				PREV = {
-					set_variable = { which = global_royalAuthority value = -10 }	
 					add_character_modifier = {
 						name = ek_law_low_mandate_change  
 						years = 10
@@ -104,8 +104,8 @@ character_event = {
 				}
 				revoke_law = ze_admin_balance
 				add_law = ze_admin_province
+				set_variable = { which = global_royalAuthority value = -10 }
 				PREV = {
-					set_variable = { which = global_royalAuthority value = -10 }
 					add_character_modifier = {
 						name = ek_law_low_mandate_change 
 						years = 10
@@ -118,14 +118,14 @@ character_event = {
 				}
 				revoke_law = ze_admin_slight_central
 				add_law = ze_admin_balance	
+				set_variable = { which = global_royalAuthority value = -10 }	
 				PREV = {
-					set_variable = { which = global_royalAuthority value = -10 }	
 					add_character_modifier = {
 						name = ek_law_low_mandate_change 
 						years = 10
 					}
 				}
-			}				
+			}
 		}
 	}	
 	

--- a/avatar - four nations restored/events/ATLA_mandate.txt
+++ b/avatar - four nations restored/events/ATLA_mandate.txt
@@ -76,7 +76,7 @@ character_event = {
 				}
 				revoke_law = ze_admin_territories
 				add_law = ze_admin_anarchy
-				set_variable = { which = global_royalAuthority value = -10 }
+				change_variable = { which = global_royalAuthority value = -10 }
 				PREV = {
 					add_character_modifier = {
 						name = ek_law_low_mandate_change 
@@ -90,7 +90,7 @@ character_event = {
 				}
 				revoke_law = ze_admin_province
 				add_law = ze_admin_territories
-				set_variable = { which = global_royalAuthority value = -10 }	
+				change_variable = { which = global_royalAuthority value = -10 }	
 				PREV = {
 					add_character_modifier = {
 						name = ek_law_low_mandate_change  
@@ -104,7 +104,7 @@ character_event = {
 				}
 				revoke_law = ze_admin_balance
 				add_law = ze_admin_province
-				set_variable = { which = global_royalAuthority value = -10 }
+				change_variable = { which = global_royalAuthority value = -10 }
 				PREV = {
 					add_character_modifier = {
 						name = ek_law_low_mandate_change 
@@ -118,7 +118,7 @@ character_event = {
 				}
 				revoke_law = ze_admin_slight_central
 				add_law = ze_admin_balance	
-				set_variable = { which = global_royalAuthority value = -10 }	
+				change_variable = { which = global_royalAuthority value = -10 }	
 				PREV = {
 					add_character_modifier = {
 						name = ek_law_low_mandate_change 

--- a/avatar - four nations restored/events/ATLA_mandate.txt
+++ b/avatar - four nations restored/events/ATLA_mandate.txt
@@ -76,46 +76,54 @@ character_event = {
 				}
 				revoke_law = ze_admin_territories
 				add_law = ze_admin_anarchy
-				set_variable = { which = global_royalAuthority value = -10 }
-				add_character_modifier = {
+				PREV = {
+					set_variable = { which = global_royalAuthority value = -10 }
+					add_character_modifier = {
 						name = ek_law_low_mandate_change 
 						years = 10
 					}
 				}
+			}
 			if = {
 				limit = {
 					has_law = ze_admin_province
 				}
 				revoke_law = ze_admin_province
 				add_law = ze_admin_territories
-				set_variable = { which = global_royalAuthority value = -10 }	
-				add_character_modifier = {
+				PREV = {
+					set_variable = { which = global_royalAuthority value = -10 }	
+					add_character_modifier = {
 						name = ek_law_low_mandate_change  
 						years = 10
 					}
-				}				
+				}
+			}		
 			if = {
 				limit = {
 					has_law = ze_admin_balance
 				}
 				revoke_law = ze_admin_balance
-				add_law = ze_admin_province	
-				set_variable = { which = global_royalAuthority value = -10 }
-				add_character_modifier = {
+				add_law = ze_admin_province
+				PREV = {
+					set_variable = { which = global_royalAuthority value = -10 }
+					add_character_modifier = {
 						name = ek_law_low_mandate_change 
 						years = 10
 					}
 				}
+			}
 			if = {
 				limit = {
 					has_law = ze_admin_slight_central
 				}
 				revoke_law = ze_admin_slight_central
 				add_law = ze_admin_balance	
-				set_variable = { which = global_royalAuthority value = -10 }	
-				add_character_modifier = {
+				PREV = {
+					set_variable = { which = global_royalAuthority value = -10 }	
+					add_character_modifier = {
 						name = ek_law_low_mandate_change 
 						years = 10
+					}
 				}
 			}				
 		}


### PR DESCRIPTION
# Bug review

Here you @TypicalCrusader used primary_title, set variable inside title scope, and a character modifier, 

<img width="369" alt="image" src="https://user-images.githubusercontent.com/51882489/185007540-42d9d8b6-e6b9-4800-81f3-6c933c130f6e.png">

so I wrapped these character-scoped actions to PREV, relating to title holder (Earth King)

<img width="500" alt="image" src="https://user-images.githubusercontent.com/51882489/185007622-1f4cb87f-adec-4e89-9101-8d3e3a3fb088.png">

---

## Result

### Before:

![image](https://user-images.githubusercontent.com/51882489/185006397-0df407bd-eb31-4da6-8f06-61c910d9445c.png)

![image](https://user-images.githubusercontent.com/51882489/185006368-c3e7a1c8-5e40-47de-b123-2cacb11af91c.png)

### After:

![image](https://user-images.githubusercontent.com/51882489/185006211-af2222a4-a50d-42fe-964a-227f58a319d3.png)

![image](https://user-images.githubusercontent.com/51882489/185007834-8b188e15-8a74-4d61-9c90-23e6b04ae19a.png)

_and the error in error.log disappeared_ 

---

## BTW

As I can see, setting a variable inside a title scope seems to be the same as setting it inside a character scope

But, maybe you @TypicalCrusader wanted to "change_" it, not to "set_" it? Like, now it was 50, now it's -10. Would'nt it be better to change it, like it was 50, then it's 40?
