### PR TITLE
Fix for Sozin dying immediately upon game start

### DIFF
--- a/avatar - four nations restored/events/ATLA_CampaignSetup.txt
+++ b/avatar - four nations restored/events/ATLA_CampaignSetup.txt
@@ -24,6 +24,7 @@ character_event = { # Event Server
 				any_character = {
 					limit = {
 						religion = fire_nation_imperialism
+						NOT = { has_character_flag = is_sozin }
 					}
 					death = { death_reason = death_missing }
 				}


### PR DESCRIPTION
ATLA_CampaignSetup.txt may contain a lot of jank inside of it and is worth diving deeper into. Right now other minor characters with fire imperialism die off bat and this can be fixed by commenting the entire chunk out but I added a simple line to make the big man himself not get culled to the code.