### PR TITLE
No more legendary avatars

### DIFF
--- a/avatar - four nations restored/common/scripted_triggers/11_atla_sub_bending_scripted_triggers.txt
+++ b/avatar - four nations restored/common/scripted_triggers/11_atla_sub_bending_scripted_triggers.txt
@@ -22,14 +22,14 @@ can_teach_sub_bending_lightning = {
 
 can_teach_sub_bending_lava = {
 	OR = {
-		trait = firebender
-		trait = avatar_firebender
+		trait = earthbender
+		trait = avatar_earthbender
 	}
 	trait = lavabender
 	FROM = {
 		OR = {
-			trait = firebender
-			trait = avatar_firebender
+			trait = earthbender
+			trait = avatar_earthbender
 		}
 		NOT = {
 			trait = lavabender

--- a/avatar - four nations restored/decisions/ATLA_religious_decisions.txt
+++ b/avatar - four nations restored/decisions/ATLA_religious_decisions.txt
@@ -274,6 +274,9 @@ decisions = {
 				religion = southern_spirituality
 				religion = bhanti_spirituality_reformed
 			}
+			NOT = {
+				has_character_flag = already_did_spirit_journey
+			}
 		}
 		allow = {
 			war = no
@@ -303,6 +306,7 @@ decisions = {
 			scaled_wealth = -0.2
 			set_character_flag = spirit_journey
 			set_character_flag = do_not_disturb
+			set_character_flag = already_did_spirit_journey
 			hidden_tooltip = {
 				character_event = { id = ATLAR.1 }
 			}

--- a/avatar - four nations restored/events/ATLA_avatar_journey.txt
+++ b/avatar - four nations restored/events/ATLA_avatar_journey.txt
@@ -1184,11 +1184,16 @@ narrative_event = {
 			90 = {
 				prestige = 1000
 				piety = 1000
-				upgrade_bending_effect = yes
 				give_nickname = nick_spirit_slayer
 				add_trait = ambitious
 				character_event = {
 					id = new_avatar_journey.4090
+				}
+				if = {
+					limit = {
+						NOT = { trait = master_bender }
+					}
+					upgrade_bending_effect = yes
 				}
 			}
 			10 = {

--- a/avatar - four nations restored/events/ATLA_barbarian_events.txt
+++ b/avatar - four nations restored/events/ATLA_barbarian_events.txt
@@ -1297,6 +1297,16 @@ narrative_event = {
 					factor = 0.5
 					trait = powerful_bender
 				}
+				mult_modifier = {
+					factor = 0.0
+					AND = {
+						trait = master_bender
+						OR = {
+							trait = avatar
+							trait = fullyrealisedavatar
+						}
+					}
+				}
 			}
 		}
 		

--- a/avatar - four nations restored/events/ATLA_random_events.txt
+++ b/avatar - four nations restored/events/ATLA_random_events.txt
@@ -231,6 +231,16 @@ character_event = { # Find Master
 		if = {
 			limit = {
 				is_bender_trigger = yes
+				OR = {
+					NOT = { trait = master_bender }
+					AND = {
+						trait = master_bender
+						NOR = {
+							trait = avatar
+							trait = fullyrealisedavatar
+						}
+					}
+				}
 			}
 			upgrade_bending_effect = yes
 		}
@@ -571,6 +581,16 @@ character_event = { # Dragon - Dragon Slain
 		if = {
 			limit = {
 				trait = firebender
+				OR = {
+					NOT = { trait = master_bender }
+					AND = {
+						trait = master_bender
+						NOR = {
+							trait = avatar
+							trait = fullyrealisedavatar
+						}
+					}
+				}
 			}
 			upgrade_bending_effect = yes
 		}
@@ -616,7 +636,21 @@ character_event = { # Badger Mole - Learning
 
 	option = {
 		name = "EVTOPTAATLAR.21"
-		upgrade_bending_effect = yes
+		if = {
+			limit = {
+				OR = {
+					NOT = { trait = master_bender }
+					AND = {
+						trait = master_bender
+						NOR = {
+							trait = avatar
+							trait = fullyrealisedavatar
+						}
+					}
+				}
+			}
+			upgrade_bending_effect = yes
+		}
 		add_trait = seismicsense_nonblind
 	}
 }

--- a/avatar - four nations restored/events/ATLA_society_agni_kai.txt
+++ b/avatar - four nations restored/events/ATLA_society_agni_kai.txt
@@ -10708,7 +10708,19 @@ character_event = {
 	option = { # Commence Training
 		name = EVTOPTA_MNSAK_5212
 		trigger = {
-			NOT = { trait = legendary_bender }
+			NOT = { 
+				OR = {
+					trait = legendary_bender
+					AND = {
+						trait = avatar
+						trait = master_bender
+					}
+					AND = {
+						trait = fullyrealisedavatar
+						trait = master_bender
+					}
+				}
+			}
 		}
 		hidden_tooltip = {
 			character_event = { id = MNSAK.5213 days = 21 }

--- a/avatar - four nations restored/events/ATLA_society_airball.txt
+++ b/avatar - four nations restored/events/ATLA_society_airball.txt
@@ -1415,7 +1415,21 @@ character_event = {
 		name = EVTOPTA_AIRBALL_1142
 		prestige = 250
 		add_society_currency_minor_effect = yes
-		upgrade_bending_effect = yes
+		if = {
+			limit = {
+				OR = {
+					NOT = { trait = master_bender }
+					AND = {
+						trait = master_bender
+						NOR = {
+							trait = avatar
+							trait = fullyrealisedavatar
+						}
+					}
+				}
+			}
+			upgrade_bending_effect = yes
+		}
 	}
 }
 
@@ -1431,7 +1445,21 @@ character_event = {
 		name = EVTOPTA_AIRBALL_1143
 		prestige = 100
 		add_society_currency_minor_effect = yes
-		upgrade_bending_effect = yes
+		if = {
+			limit = {
+				OR = {
+					NOT = { trait = master_bender }
+					AND = {
+						trait = master_bender
+						NOR = {
+							trait = avatar
+							trait = fullyrealisedavatar
+						}
+					}
+				}
+			}
+			upgrade_bending_effect = yes
+		}
 	}
 }
 


### PR DESCRIPTION
Limits every instance where the Avatar was able to get the Legendary Bender trait which removed their Avatar trait

Makes Spiritual Journey once in a lifetime

Lavabending can now be taught by an earthbender that knows lavabender, rather than a firebender that violated the laws of bending and somehow managed to lavabend.