### PR TITLE
rip_seclusion_events reversion

### DIFF
--- a/avatar - four nations restored/events/rip_seclusion_events.txt
+++ b/avatar - four nations restored/events/rip_seclusion_events.txt
@@ -213,7 +213,7 @@ character_event = {
 					has_minor_title = title_councilmember_emperor
 				}
 			}
-			force_host = { character = ROOT }
+			force_host = ROOT
 		}
 		hidden_tooltip = {
 			character_event = { id = RIP.12000 }


### PR DESCRIPTION
May have broken something crucial. Have reverted a change to hopefully fix the issue - since I don't think this is how force_host works.