### PR TITLE
Updated ATLA Traits

### DIFF
--- a/avatar - four nations restored/common/traits/06_atla_traits.txt
+++ b/avatar - four nations restored/common/traits/06_atla_traits.txt
@@ -22,7 +22,6 @@ avatar = {
 	customizer = no
 	random = no
 	
-	education = yes
 	culture_flex = 80
 	religion_flex = 80
 	cannot_marry = yes
@@ -52,7 +51,6 @@ fully_realised_avatar = { #Trait replaces all bending traits, so gives all their
 	customizer = no
 	random = no
 	
-	education = yes #For display purposes
 	general_opinion = 20
 	
 	defensive_plot_power_modifier = 0.3
@@ -93,8 +91,6 @@ team_avatar = {
 	random = no
 	cached = yes
 	
-	education = yes
-	
 	monthly_character_prestige = 0.5
 	general_opinion = 5
 	same_opinion = 25
@@ -111,8 +107,6 @@ team_avatar = {
 former_team_avatar = {
 	customizer = no
 	random = no
-	
-	education = yes
 	
 	monthly_character_prestige = 0.25
 	general_opinion = 5
@@ -140,14 +134,12 @@ canon_character = { #Not strictly avatar related but close enough
 	hidden = yes
 	random = no
 	customizer = no
-	cached = yes
 }
 
 bad_avatar = {
 	customizer = no
 	random = no
-	
-	education = yes #For display purposes
+
 	general_opinion = -30
 	monthly_character_piety = -1
 	monthly_character_prestige = -1


### PR DESCRIPTION
Removed education tag from Avatar traits, should stop random Avatar spawns. Also removed cached = yes from canon_characters, since it's never ever called in a way that would matter. Yay save bloat reduction!