### PR TITLE
Update ATLA_avatar_system.txt

### DIFF
--- a/avatar - four nations restored/events/ATLA_avatar_system.txt
+++ b/avatar - four nations restored/events/ATLA_avatar_system.txt
@@ -359,6 +359,8 @@ province_event = {
 	id = NAE.0041
 	hide_window = yes
 	
+	is_triggered_only = yes
+	
 	immediate = {
 		create_character = {
 			age = 16


### PR DESCRIPTION
NAE.0041 could trigger randomly. Now it can't!
This should stop the plague of 30+ avatars spawning in.